### PR TITLE
Transform fields on EmbeddedDocumentField

### DIFF
--- a/rest_framework_mongoengine/fields.py
+++ b/rest_framework_mongoengine/fields.py
@@ -119,7 +119,7 @@ class EmbeddedDocumentField(MongoDocumentField):
         if obj is None:
             return None
         else:
-            return self.model_field.to_mongo(obj)
+            return self.transform_object(obj, self.depth)
 
     def from_native(self, value):
         return self.model_field.to_python(value)


### PR DESCRIPTION
Fix in relation to #40 

``` python
class C(Document):
    name = StringField()

class B(EmbeddedDocument):
    name = StringField()
    related = ReferenceField(C)

class A(Document):
    related = EmbeddedDocumentField(B)
```

Before change an `ObjectId(...) is not JSON serializable` would be generated from the `B.related` field when attempting to serialize `A`
