### PR TITLE
Add DBRef case in transform_object

### DIFF
--- a/rest_framework_mongoengine/fields.py
+++ b/rest_framework_mongoengine/fields.py
@@ -1,4 +1,5 @@
 from bson.errors import InvalidId
+from bson.dbref import DBRef
 from django.core.exceptions import ValidationError
 from django.utils.encoding import smart_str
 from mongoengine import dereference
@@ -53,6 +54,9 @@ class MongoDocumentField(serializers.WritableField):
                 # Return primary key if exists, else return default text
                 return smart_str(getattr(obj, 'pk', 'Max recursion depth exceeded'))
             return self.transform_document(obj, depth)
+        elif isinstance(obj, DBRef):
+            # DBRef
+            return self.transform_object(obj.id, depth)
         elif isinstance(obj, dict):
             # Dictionaries
             return self.transform_dict(obj, depth)


### PR DESCRIPTION
When I tried to serialize an object with ReferenceField I found that these fields couldn't be serialized because transform_object method wasn't expect DBRef objects. The solution was check if the object is an instance of DBRef and, if affirmative, call transform_object with obj.id (an ObjectId instance). The object is now serialized successfully.