### PR TITLE
Field error handling in serializer and ReferenceField error messages

### DIFF
--- a/rest_framework_mongoengine/fields.py
+++ b/rest_framework_mongoengine/fields.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.utils.encoding import smart_str
+from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import serializers
 from bson.errors import InvalidId
@@ -85,6 +86,10 @@ class ReferenceField(DocumentField):
     We always dereference DBRef object before serialization
     TODO: Maybe support DBRef too?
     """
+    default_error_messages = {
+        'invalid_dbref': _('Unable to convert to internal value.'),
+        'invalid_doc': _('DBRef invalid dereference.'),
+    }
 
     type_label = 'ReferenceField'
 
@@ -96,13 +101,13 @@ class ReferenceField(DocumentField):
         try:
             dbref = self.model_field.to_python(data)
         except InvalidId:
-            raise ValidationError(self.error_messages['invalid'])
+            raise ValidationError(self.error_messages['invalid_dbref'])
 
         instance = dereference.DeReference()([dbref])[0]
 
         # Check if dereference was successful
         if not isinstance(instance, Document):
-            msg = self.error_messages['invalid']
+            msg = self.error_messages['invalid_doc']
             raise ValidationError(msg)
 
         return instance

--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -446,7 +446,11 @@ class DynamicDocumentSerializer(DocumentSerializer):
         fields += self._get_dynamic_fields(instance).values()
 
         for field in fields:
-            attribute = field.get_attribute(instance)
+            try:
+                attribute = field.get_attribute(instance)
+            except serializers.SkipField:
+                continue
+
             if attribute is None:
                 ret[field.field_name] = None
             else:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-mongoengine',
-    version='2.0.2',
+    version='2.0.3',
     description='MongoEngine support for Django Rest Framework.',
     packages=['rest_framework_mongoengine',],
     license='see https://github.com/umutbozkurt/django-rest-framework-mongoengine/blob/master/LICENSE',


### PR DESCRIPTION
I have a few related/different fixes in this pull request. If you would like me to do one at a time in the future please let me know!

* Updated ReferenceField to show error messages (was getting an AttributeError on bad dereference)
* Split the 'invalid' error messages in ReferenceField:
    * Error message when the DBRef could not be converted to an internal representation
    * Error message when a Document was not produce from dereferencing the DBRef object
* Updated to_representation to catch SkipField in the same manner as DRF

I also tried to be descriptive in my commits. There is a little bit more information in there.

Thanks!
-Timothy