### PR TITLE
fixed embedded documents' data initialization in is_valid

### DIFF
--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -168,7 +168,7 @@ class DocumentSerializer(serializers.ModelSerializer):
         valid = super(DocumentSerializer, self).is_valid(raise_exception=raise_exception)
 
         for embedded_field in self.embedded_document_serializer_fields:
-            embedded_field._initial_data = self.validated_data.pop(embedded_field.field_name, serializers.empty)
+            embedded_field.initial_data = self.validated_data.pop(embedded_field.field_name, serializers.empty)
             valid &= embedded_field.is_valid(raise_exception=raise_exception)
 
         return valid


### PR DESCRIPTION
Simple fix to DocumentSerializer.is_valid when using EmbeddedDocumentSerializers. See issue #72 