### PR TITLE
DBRef can't be serialised to JSON fix

### DIFF
--- a/rest_framework_mongoengine/fields.py
+++ b/rest_framework_mongoengine/fields.py
@@ -6,6 +6,7 @@ from mongoengine.base.document import BaseDocument
 from mongoengine.document import Document
 from rest_framework import serializers
 from mongoengine.fields import ObjectId
+import bson
 
 
 class MongoDocumentField(serializers.WritableField):

--- a/rest_framework_mongoengine/fields.py
+++ b/rest_framework_mongoengine/fields.py
@@ -85,6 +85,10 @@ class ReferenceField(MongoDocumentField):
         return instance
 
     def to_native(self, obj):
+        #if type is DBRef it means Mongo can't find the actual reference object
+        #prevent the JSON serializable error by setting the object to None
+        if type(obj) == bson.dbref.DBRef:
+            obj = None
         return self.transform_object(obj, self.depth - 1)
 
 


### PR DESCRIPTION
If you create a document with a reference Document, then delete that reference
document the ReferenceField on the serializer will return a DBRef, because mongo 
can't resolve the location of the document (it has been deleted). That DBRef
throws the can't be serialzed to JSON error. We could serialize it using
pymono, but I think it the context of a REST call it doesn't make sense
to get back the DBRef, you can't do anything with it. Rather this change
just sets that DBRef to None so from the serialized data, you will know
that the referenced document deosn't exist.