### PR TITLE
Adding renderer support for YAML

### DIFF
--- a/rest_framework_mongoengine/renderers.py
+++ b/rest_framework_mongoengine/renderers.py
@@ -1,0 +1,11 @@
+from rest_framework.renderers import YAMLRenderer as drf_YAMLRenderer
+from rest_framework.utils.encoders import SafeDumper
+from mongoengine.base.datastructures import BaseDict, BaseList
+
+
+class YAMLRenderer(drf_YAMLRenderer):
+    pass
+
+
+SafeDumper.add_representer(BaseDict, SafeDumper.represent_dict)
+SafeDumper.add_representer(BaseList, SafeDumper.represent_list)


### PR DESCRIPTION
Current YAML renderer does not have a mapping for mongoengine data structures BaseDict and BaseList. Adding the mapping to SafeDumper and creating YAMLRenderer sub-class to be able to import it in settings.

I have noticed there is a rest_framework_yaml project; I do not know if DRF plans on splitting off all YAML support into that project.

Tested on deeply nested output.