### PR TITLE
'null' model field kwarg in Mongoengine 0.9.0 vs 'allow_null' on serializer field

### DIFF
--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -341,7 +341,7 @@ class DocumentSerializer(serializers.ModelSerializer):
             kwargs['required'] = False
             kwargs['default'] = model_field.default
 
-        if model_field.null:
+        if hasattr(model_field, 'null') and model_field.null:
             kwargs['allow_null'] = True
 
         if model_field.__class__ == models.TextField:

--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -66,6 +66,7 @@ def raise_errors_on_nested_writes(method_name, serializer, validated_data):
     #     address = serializer.CharField('profile.address')
     assert not any(
         '.' in field.source and (key in validated_data)
+        and isinstance(validated_data[key], (list, dict))
         for key, field in serializer.fields.items()
     ), (
         'The `.{method_name}()` method does not support writable dotted-source '

--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -341,6 +341,9 @@ class DocumentSerializer(serializers.ModelSerializer):
             kwargs['required'] = False
             kwargs['default'] = model_field.default
 
+        if model_field.null:
+            kwargs['allow_null'] = True
+
         if model_field.__class__ == models.TextField:
             kwargs['widget'] = widgets.Textarea
 

--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -125,6 +125,7 @@ class DocumentSerializer(serializers.ModelSerializer):
             raise AssertionError('You should set `model` attribute on %s.' % type(self).__name__)
 
     MAX_RECURSION_DEPTH = 5  # default value of depth
+
     field_mapping = {
         me_fields.FloatField: drf_fields.FloatField,
         me_fields.IntField: drf_fields.IntegerField,
@@ -268,6 +269,10 @@ class DocumentSerializer(serializers.ModelSerializer):
                     # Fields with choices get coerced into `ChoiceField`
                     # instead of using their regular typed field.
                     field_cls = drf_fields.ChoiceField
+                    kwargs = {
+                        key: kwargs[key] for key in kwargs
+                        if key in ['required', 'allow_blank', 'allow_null', 'choices']
+                    }
                 if not issubclass(field_cls, drf_fields.CharField) and not issubclass(field_cls, drf_fields.ChoiceField):
                     # `allow_blank` is only valid for textual fields.
                     kwargs.pop('allow_blank', None)
@@ -341,6 +346,9 @@ class DocumentSerializer(serializers.ModelSerializer):
             kwargs['required'] = False
             kwargs['default'] = model_field.default
 
+        if model_field.choices:
+            kwargs['choices'] = model_field.choices
+
         if hasattr(model_field, 'null') and model_field.null:
             kwargs['allow_null'] = True
 
@@ -348,7 +356,9 @@ class DocumentSerializer(serializers.ModelSerializer):
             kwargs['widget'] = widgets.Textarea
 
         attribute_dict = {
-            me_fields.StringField: ['max_length'],
+            me_fields.StringField: ['min_length', 'max_length'],
+            me_fields.IntField: ['min_value', 'max_value'],
+            me_fields.FloatField: ['min_value', 'max_value'],
             me_fields.DecimalField: ['min_value', 'max_value'],
             me_fields.EmailField: ['max_length'],
             me_fields.FileField: ['max_length'],


### PR DESCRIPTION
DocumentSerializer's _get_field_kwargs_ method should automatically set 'allow_null' kwarg based on 'null' model field kwarg (introduced in Mongoengine 0.9.0).
_get_field_kwargs_  safely (won't throw AttributeError pre-0.9.0) checks for null attribute on model_field and sets its own kwargs accordingly.