### PR TITLE
Drf 3.1.0 updates

### DIFF
--- a/rest_framework_mongoengine/fields.py
+++ b/rest_framework_mongoengine/fields.py
@@ -141,6 +141,7 @@ class EmbeddedDocumentField(DocumentField):
         except KeyError:
             raise ValueError("EmbeddedDocumentField requires 'document_type' kwarg")
 
+        self.depth = kwargs.pop('depth')
         super(EmbeddedDocumentField, self).__init__(*args, **kwargs)
 
     def to_representation(self, value):

--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -188,7 +188,7 @@ class DocumentSerializer(serializers.ModelSerializer):
         fields = getattr(self.Meta, 'fields', None)
         exclude = getattr(self.Meta, 'exclude', None)
         depth = getattr(self.Meta, 'depth', 0)
-        extra_kwargs = getattr(self.Meta, 'extra_kwargs', {})
+        extra_kwargs = self.get_extra_kwargs()
 
         if fields and not isinstance(fields, (list, tuple)):
             raise TypeError(
@@ -204,14 +204,12 @@ class DocumentSerializer(serializers.ModelSerializer):
 
         assert not (fields and exclude), "Cannot set both 'fields' and 'exclude'."
 
-        extra_kwargs = self._include_additional_options(extra_kwargs)
-
         # # Retrieve metadata about fields & relationships on the model class.
         info = get_field_info(model)
 
         # Use the default set of field names if none is supplied explicitly.
         if fields is None:
-            fields = self._get_default_field_names(declared_fields, info)
+            fields = self.get_default_field_names(declared_fields, info)
             exclude = getattr(self.Meta, 'exclude', None)
             if exclude is not None:
                 for field_name in exclude:
@@ -336,6 +334,7 @@ class DocumentSerializer(serializers.ModelSerializer):
 
         if type(model_field) is me_fields.EmbeddedDocumentField:
             kwargs['document_type'] = model_field.document_type
+            kwargs['depth'] = getattr(self.Meta, 'depth', self.MAX_RECURSION_DEPTH)
 
         if model_field.default:
             kwargs['required'] = False

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-mongoengine',
-    version='2.0.3',
+    version='2.1.0',
     description='MongoEngine support for Django Rest Framework.',
     packages=['rest_framework_mongoengine',],
     license='see https://github.com/umutbozkurt/django-rest-framework-mongoengine/blob/master/LICENSE',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ setup(
     keywords=['mongoengine', 'serializer', 'django rest framework'],
     author='Umut Bozkurt',
     author_email='umutbozkurt92@gmail.com',
-    requires=['mongoengine', 'djangorestframework'],
+    requires=[
+        'mongoengine',
+        'djangorestframework>=3.1.0'
+    ],
     classifiers=['Development Status :: 5 - Production/Stable',
                  'License :: OSI Approved :: MIT License',
                  'Natural Language :: English',


### PR DESCRIPTION
Updates to allow use with DRF-3.1.0. This patch is not backwards compatible. Also, these look like the minimal changes needed. But, I do not know if I took the best approach on get_fields() in serializer.py.

Will comment my code in this pull request.

Thanks!
-Timothy