### PR TITLE
use local version of get_document_or_404 if missing in mongoengine.

### DIFF
--- a/rest_framework_mongoengine/generics.py
+++ b/rest_framework_mongoengine/generics.py
@@ -1,8 +1,12 @@
 from rest_framework import mixins
 from rest_framework import generics as drf_generics
 
-from mongoengine.django.shortcuts import get_document_or_404
 from mongoengine.queryset.base import BaseQuerySet
+
+try:
+    from mongoengine.django.shortcuts import get_document_or_404
+except ImportError:
+    from .utils import get_document_or_404
 
 
 class GenericAPIView(drf_generics.GenericAPIView):

--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -216,7 +216,13 @@ class DocumentSerializer(serializers.ModelSerializer):
 
         # Use the default set of field names if none is supplied explicitly.
         if fields is None:
-            fields = self._get_default_field_names(declared_fields, info)
+            # Since rest_framework ~= 3.1.3 '_get_default_field_names' is made
+            # public attribute.
+            try:
+                fields = self._get_default_field_names(declared_fields, info)
+            except AttributeError:
+                fields = self.get_default_field_names(declared_fields, info)
+
             exclude = getattr(self.Meta, 'exclude', None)
             if exclude is not None:
                 for field_name in exclude:

--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -204,7 +204,12 @@ class DocumentSerializer(serializers.ModelSerializer):
 
         assert not (fields and exclude), "Cannot set both 'fields' and 'exclude'."
 
-        extra_kwargs = self._include_additional_options(extra_kwargs)
+        # Since rest_framework ~= 3.1.3 '_include_additional_options' is renamed
+        # to 'get_extra_kwargs'
+        try:
+            extra_kwargs = self._include_additional_options(extra_kwargs)
+        except AttributeError:
+            extra_kwargs = self.get_extra_kwargs()
 
         # # Retrieve metadata about fields & relationships on the model class.
         info = get_field_info(model)

--- a/rest_framework_mongoengine/utils.py
+++ b/rest_framework_mongoengine/utils.py
@@ -4,6 +4,7 @@ from django.utils import six
 
 from mongoengine.base.common import get_document
 from mongoengine.queryset import QuerySet
+from mongoengine.errors import ValidationError
 import mongoengine
 
 from rest_framework.compat import OrderedDict

--- a/rest_framework_mongoengine/utils.py
+++ b/rest_framework_mongoengine/utils.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils import six
 
 from mongoengine.base.common import get_document
+from mongoengine.queryset import QuerySet
 import mongoengine
 
 from rest_framework.compat import OrderedDict
@@ -81,3 +82,24 @@ def get_field_info(model):
     )
 
     return FieldInfo(pk, fields, forward_relations, reverse_relations, fields_and_pk, relations)
+
+def get_document_or_404(cls, *args, **kwargs):
+    """
+    Uses get() to return an document, or raises a Http404 exception if the document
+    does not exist.
+
+    cls may be a Document or QuerySet object. All other passed
+    arguments and keyword arguments are used in the get() query.
+
+    Note: Like with get(), an MultipleObjectsReturned will be raised if more than one
+    object is found.
+
+    Inspired by django.shortcuts.*
+    """
+    queryset = cls if isinstance(cls, QuerySet) else cls.objects
+
+    try:
+        return queryset.get(*args, **kwargs)
+    except (queryset._document.DoesNotExist, ValidationError):
+        from django.http import Http404
+        raise Http404('No %s matches the given query.' % queryset._document._class_name)


### PR DESCRIPTION
Since mongoengine >= 0.1 started providing additional extension for django support, which is not released yet, this fix is required for the time being.