### PR TITLE
Removed get_document_or_404() in generics.py and replaced it with its…

### DIFF
--- a/rest_framework_mongoengine/generics.py
+++ b/rest_framework_mongoengine/generics.py
@@ -1,7 +1,6 @@
 from rest_framework import mixins
 from rest_framework import generics as drf_generics
 
-from mongoengine.django.shortcuts import get_document_or_404
 from mongoengine.queryset.base import BaseQuerySet
 
 
@@ -24,7 +23,7 @@ class GenericAPIView(drf_generics.GenericAPIView):
 
     def get_object(self):
         """
-        *** Inherited from DRF 3 GenericAPIView, swapped get_object_or_404() with get_document_or_404() ***
+        *** Inherited from DRF 3 GenericAPIView. ***
 
         Returns the object the view is displaying.
 
@@ -45,7 +44,11 @@ class GenericAPIView(drf_generics.GenericAPIView):
         )
 
         filter_kwargs = {self.lookup_field: self.kwargs[lookup_url_kwarg]}
-        obj = get_document_or_404(queryset, **filter_kwargs)
+        try:
+            return queryset.get(*args, **kwargs)
+        except (queryset._document.DoesNotExist, ValidationError):
+            from django.http import Http404
+        raise Http404('No %s matches the given query.' % queryset._document._class_name)
 
         # May raise a permission denied
         self.check_object_permissions(self.request, obj)

--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -157,6 +157,9 @@ class DocumentSerializer(serializers.ModelSerializer):
 
     embedded_document_serializer_fields = []
 
+    def _include_additional_options(self, *args, **kwargs):
+        return self.get_extra_kwargs()
+
     def get_validators(self):
         validators = getattr(getattr(self, 'Meta', None), 'validators', [])
         return validators


### PR DESCRIPTION
… actual implementation because Django was decoupled from mongoengine in the last version of mongoengine. Added _include_additional_option() to serializers.py - framework was crashing without it.