### PR TITLE
EmbeddedDocumentSerializer get_field_names method name fix

### DIFF
--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -488,7 +488,7 @@ class EmbeddedDocumentSerializer(DocumentSerializer):
 
         return instance
 
-    def _get_default_field_names(self, declared_fields, model_info):
+    def get_default_field_names(self, declared_fields, model_info):
         """
         EmbeddedDocuments don't have `id`s so do not include `id` to field names
         """


### PR DESCRIPTION
I was having some test failures after merging #88 changes to my fork. After some research it turned out that the changes to method calls are bypassing (_)get_default_field_names method of EmbeddedDocumentSerializer, which causes AttributeError in said method in rest_framework.serializers.ModelSerializer. Removing an underscore from the method name fixes it (ie. the override is back in effect).