### PR TITLE
Proposed fix to #120 (Py3 incompatibility in ObjectId field)

### DIFF
--- a/rest_framework_mongoengine/fields.py
+++ b/rest_framework_mongoengine/fields.py
@@ -178,7 +178,7 @@ class ObjectIdField(DocumentField):
 
     def to_internal_value(self, data):
         try:
-            return ObjectId(unicode(data))
+            return ObjectId(smart_str(data))
         except Exception as e:
             raise serializers.ValidationError(e.message)
 


### PR DESCRIPTION
ObjectId field's 'to_internal_value' uses 'unicode' function - throws 'unicode is not defined' exception in Py3. Furthermore, this exception does not have a 'message' property which makes the entire except block fall flat.