### PR TITLE
Changed get_field_kwargs and get_relation_kwargs for mongoengine 0.10.5 compatibility.

### DIFF
--- a/rest_framework_mongoengine/utils.py
+++ b/rest_framework_mongoengine/utils.py
@@ -134,10 +134,10 @@ def get_field_kwargs(field_name, model_field):
     # Gets removed for everything else.
     kwargs['model_field'] = model_field
 
-    if model_field.verbose_name and needs_label(model_field, field_name):
+    if hasattr(model_field, 'verbose_name') and needs_label(model_field, field_name):
         kwargs['label'] = capfirst(model_field.verbose_name)
 
-    if model_field.help_text:
+    if hasattr(model_field, 'help_text'):
         kwargs['help_text'] = model_field.help_text
 
     if isinstance(model_field, me_fields.DecimalField):
@@ -205,11 +205,10 @@ def get_relation_kwargs(field_name, relation_info):
 
 
     if model_field:
-        if model_field.verbose_name and needs_label(model_field, field_name):
+        if hasattr(model_field, 'verbose_name') and needs_label(model_field, field_name):
             kwargs['label'] = capfirst(model_field.verbose_name)
-        help_text = model_field.help_text
-        if help_text:
-            kwargs['help_text'] = help_text
+        if hasattr(model_field, 'help_text'):
+            kwargs['help_text'] = model_field.help_text
         if kwargs.get('read_only', False):
             # If this field is read-only, then return early.
             # No further keyword arguments are valid.


### PR DESCRIPTION
mongoengine 0.10.5 was published to PyPI yesterday. In this version, the "verbose_name" and "help_text" attributes of fields are no longer set by default. For details, see:
https://github.com/MongoEngine/mongoengine/commit/c0e7f341cb16b740bcfe5d3536e64ac94a30a836#diff-bf75ac33c85aac443260852e16396a3b

This pull request fixes the current problem by using "hasattr" to check for the existence of the "verbose_name" and "help_text" attributes.