### PR TITLE
Fixed test_patching, test_retrival -> test_retrieval, tearDown() -> doCleanups().

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,10 @@ env:
     - TOX_ENV=dj19-py35-me09
     - TOX_ENV=dj19-py27-me010
     - TOX_ENV=dj19-py35-me010
-# DRF is not yet compatible with Django1.10, but in future it should be:
-#    - TOX_ENV=dj110-py27-me09
-#    - TOX_ENV=dj110-py35-me09
-#    - TOX_ENV=dj110-py27-me010
-#    - TOX_ENV=dj110-py35-me010
+    - TOX_ENV=dj110-py27-me09
+    - TOX_ENV=dj110-py35-me09
+    - TOX_ENV=dj110-py27-me010
+    - TOX_ENV=dj110-py35-me010
 
 matrix:
     fast_finish: true

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -393,7 +393,7 @@ class TestRegexStringValidation(TestCase):
 class TestIntegration(TestCase):
     maxDiff = 0
 
-    def tearDown(self):
+    def doCleanups(self):
         RegularModel.drop_collection()
 
     def test_parsing(self):
@@ -437,7 +437,7 @@ class TestIntegration(TestCase):
         }
         assert serializer.validated_data == expected
 
-    def test_retrival(self):
+    def test_retrieval(self):
         instance = RegularModel.objects.create(
             str_field="str",
             str_regex_field="valid_regex_str",

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -81,7 +81,7 @@ class TestSerializer(DocumentSerializer):
 
 
 class TestIntegration(TestCase):
-    def tearDown(self):
+    def doCleanups(self):
         BasicCompoundDoc.drop_collection()
 
     def test_parsing(self):
@@ -104,7 +104,7 @@ class TestIntegration(TestCase):
         }
         assert serializer.validated_data == expected
 
-    def test_retrival(self):
+    def test_retrieval(self):
         instance = BasicCompoundDoc.objects.create(
             list_field=["1", 2, 3.0],
             int_list_field=[1, 2, 3],

--- a/tests/test_dumb.py
+++ b/tests/test_dumb.py
@@ -61,7 +61,7 @@ class TestIntegration(TestCase):
 
     Test if all operations performed correctly
     """
-    def tearDown(self):
+    def doCleanups(self):
         DumbDocument.drop_collection()
 
     def test_parsing(self):

--- a/tests/test_embedded.py
+++ b/tests/test_embedded.py
@@ -314,7 +314,7 @@ class TestEmbeddedIntegration(TestCase):
 
 
 class TestEmbeddingIntegration(TestCase):
-    def tearDown(self):
+    def doCleanups(self):
         EmbeddingDoc.drop_collection()
 
     def test_retrieve(self):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -35,7 +35,7 @@ class TestObjectId(FieldTest, TestCase):
 
 class TestDocumentField(TestCase):
 
-    def tearDown(self):
+    def doCleanups(self):
         DumbDocument.drop_collection()
 
     field = DocumentField(model_field=DumbDocument.foo)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -63,7 +63,7 @@ class TestFilesIntegration(TestCase):
         self.files = [open(pwd + "cat1.jpg", "rb"), open(pwd + "cat2.jpg", "rb")]
         self.uploads = [UploadedFile(f, f.name, "image/jpeg", os.path.getsize(f.name)) for f in self.files]
 
-    def tearDown(self):
+    def doCleanups(self):
         FileDoc.drop_collection()
         FileDoc._get_db().drop_collection('files')
         for f in self.files:

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -47,7 +47,7 @@ class TestBasicViews(TestCase):
             for obj in self.objects.all()
         ]
 
-    def tearDown(self):
+    def doCleaups(self):
         DumbDocument.drop_collection()
 
     def test_list(self):

--- a/tests/test_patching.py
+++ b/tests/test_patching.py
@@ -66,7 +66,7 @@ class TestPatchParsing(TestCase):
             {'path': "/emb/name/bla", 'op': "set", 'value': None},
         ])
         assert not patch.is_valid()
-        assert patch.errors == [{}, {'path': "Missing elem: 'bla'"}, {'path': "Missing elem: 'bla'"}, {'path': "Missing elem: 'bla'"}]
+        assert patch.errors == [[u'Not a valid string.'], {'path': "Missing elem: 'bla'"}, {'path': "Missing elem: 'bla'"}, {'path': "Missing elem: 'bla'"}]
 
     def test_parsing_values(self):
         patch = Patch(DumbSerializer(), data=[

--- a/tests/test_patching.py
+++ b/tests/test_patching.py
@@ -128,7 +128,7 @@ class TestPatchParsing(TestCase):
 
 
 class TestPatchApplying(TestCase):
-    def tearDown(self):
+    def doCleanups(self):
         PatchingDumbDocument.drop_collection()
 
     def test_patch_obj(self):
@@ -227,7 +227,7 @@ class TestView(PatchModelMixin, GenericViewSet):
 class TestPatchingView(APITestCase):
     client_class = APIRequestFactory
 
-    def tearDown(self):
+    def doCleanups(self):
         PatchingDumbDocument.drop_collection()
 
     def test_patch_obj(self):

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -68,7 +68,7 @@ class RecursiveReferencingDoc(Document):
 
 
 class TestReferenceField(TestCase):
-    def tearDown(self):
+    def doCleanups(self):
         ReferencedDoc.drop_collection()
         IntReferencedDoc.drop_collection()
         OtherReferencedDoc.drop_collection()
@@ -128,7 +128,7 @@ class TestReferenceField(TestCase):
 
 
 class TestGenericReferenceField(TestCase):
-    def tearDown(self):
+    def doCleanups(self):
         ReferencedDoc.drop_collection()
         IntReferencedDoc.drop_collection()
         OtherReferencedDoc.drop_collection()
@@ -178,7 +178,7 @@ class TestGenericReferenceField(TestCase):
 
 
 class TestComboReferenceField(TestCase):
-    def tearDown(self):
+    def doCleanups(self):
         ReferencedDoc.drop_collection()
 
     def test_input_ref(self):
@@ -348,7 +348,7 @@ class TestRelationalFieldDisplayValue(TestCase):
         ]
         self.ids = list(map(lambda e: str(e.id), self.objects))
 
-    def tearDown(self):
+    def doCleanups(self):
         DisplayableReferencedModel.drop_collection()
 
     def test_default_display_value(self):
@@ -386,11 +386,11 @@ class TestReferenceIntegration(TestCase):
             name='Foo'
         )
 
-    def tearDown(self):
+    def doCleanups(self):
         ReferencedDoc.drop_collection()
         ReferencingDoc.drop_collection()
 
-    def test_retrival(self):
+    def test_retrieval(self):
         instance = ReferencingDoc.objects.create(ref=self.target)
 
         class TestSerializer(DocumentSerializer):
@@ -405,7 +405,7 @@ class TestReferenceIntegration(TestCase):
         }
         assert serializer.data == expected
 
-    def test_retrival_deep(self):
+    def test_retrieval_deep(self):
         instance = ReferencingDoc.objects.create(ref=self.target)
 
         class TestSerializer(DocumentSerializer):
@@ -474,11 +474,11 @@ class TestGenericReferenceIntegration(TestCase):
     def setUp(self):
         self.target = ReferencedDoc.objects.create(name='Foo')
 
-    def tearDown(self):
+    def doCleanups(self):
         ReferencedDoc.drop_collection()
         GenericReferencingDoc.drop_collection()
 
-    def test_retrival(self):
+    def test_retrieval(self):
         instance = GenericReferencingDoc.objects.create(ref=self.target)
 
         class TestSerializer(DocumentSerializer):
@@ -493,7 +493,7 @@ class TestGenericReferenceIntegration(TestCase):
         }
         assert serializer.data == expected
 
-    def test_retrival_deep(self):
+    def test_retrieval_deep(self):
         instance = GenericReferencingDoc.objects.create(ref=self.target)
 
         class TestSerializer(DocumentSerializer):
@@ -583,11 +583,11 @@ class TestComboReferenceIntegration(TestCase):
     def setUp(self):
         self.target = ReferencedDoc.objects.create(name='Foo')
 
-    def tearDown(self):
+    def doCleanups(self):
         ReferencedDoc.drop_collection()
         ReferencingDoc.drop_collection()
 
-    def test_retrival(self):
+    def test_retrieval(self):
         instance = ReferencingDoc.objects.create(ref=self.target)
         serializer = ComboReferencingSerializer(instance)
         expected = {
@@ -596,7 +596,7 @@ class TestComboReferenceIntegration(TestCase):
         }
         assert serializer.data == expected
 
-    def test_retrival_deep(self):
+    def test_retrieval_deep(self):
         instance = ReferencingDoc.objects.create(ref=self.target)
 
         class TestSerializer(DocumentSerializer):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -42,7 +42,7 @@ class TestUniqueValidation(TestCase):
     def setUp(self):
         self.instance = NonValidatingModel.objects.create(name='existing')
 
-    def tearDown(self):
+    def doCleanups(self):
         NonValidatingModel.drop_collection()
 
     def test_repr(self):
@@ -124,7 +124,7 @@ class TestUniqueTogetherValidation(TestCase):
             code=1
         )
 
-    def tearDown(self):
+    def doCleanups(self):
         NonValidatingModel.drop_collection()
         NullValidatingModel.drop_collection()
 
@@ -245,7 +245,7 @@ class UniqueTogetherModel(Document):
 
 
 class TestUniqueTogetherSerializer(TestCase):
-    def tearDown(self):
+    def doCleanups(self):
         NonValidatingModel.drop_collection()
         NullValidatingModel.drop_collection()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
-envlist=dj{18,19}-py{27,35}-me{09,010}
-# DRF is not yet compatible with Django 1.10, but in future it should be:
-# envlist=dj{18,19,110}-py{27,35}-me{09,010}
+envlist=dj{18,19,110}-py{27,35}-me{09,010}
 
 [testenv]
 commands = ./runtests.py --nolint {posargs} --coverage
@@ -9,7 +7,7 @@ deps =
     -rrequirements/requirements-testing.txt
     dj18: Django==1.8.*
     dj19: Django==1.9.*
-#    dj110: Django==1.10rc1
+    dj110: Django==1.10.*
     djangorestframework==3.*
     blinker==1.*
     me09: mongoengine==0.9.*


### PR DESCRIPTION
- Fixed failing unit-test in `test_patching.py` (started to fail due to update of DRF)
- Fixed typo: `test_retrival()` -> `test_retrieval()` in unit-tests.
- Replaced all occurrences of `tearDown()` method in unit-tests with `doCleanup()` (to keep the database clean even in case of a failing `setUp()`).

@qwiglydee 
Maxim, can we do a new PyPI release? Cause from time to time guys are complaining about incorrect behavior of pip package.