### PR TITLE
Support Mongoengine 0.11.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,20 @@ env:
     - TOX_ENV=dj18-py35-me09
     - TOX_ENV=dj18-py27-me010
     - TOX_ENV=dj18-py35-me010
+    - TOX_ENV=dj18-py27-me011
+    - TOX_ENV=dj18-py35-me011
     - TOX_ENV=dj19-py27-me09
     - TOX_ENV=dj19-py35-me09
     - TOX_ENV=dj19-py27-me010
     - TOX_ENV=dj19-py35-me010
+    - TOX_ENV=dj19-py27-me011
+    - TOX_ENV=dj19-py35-me011
     - TOX_ENV=dj110-py27-me09
     - TOX_ENV=dj110-py35-me09
     - TOX_ENV=dj110-py27-me010
     - TOX_ENV=dj110-py35-me010
+    - TOX_ENV=dj110-py27-me011
+    - TOX_ENV=dj110-py35-me011
 
 matrix:
     fast_finish: true

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ The features and differences of this package are described in [API documentation
 
 * Django == 1.*
 * djangorestframework == 3.*
-* mongoengine == 0.10.* | 0.9.*
+* mongoengine == 0.11.* | 0.10.* | 0.9.*
 * blinker == 1.* (for mongoengine referencefields to work)
+* With mongoengine 0.11: pymongo == 3.*
 * With mongoengine 0.10: pymongo == 3.*
 * With mongoengine 0.9: pymongo == 2.*
 
@@ -38,7 +39,7 @@ The features and differences of this package are described in [API documentation
 
 ### do not use git clone!
 
-It may contain non-working code. Before using it, run tests to ensure the code is working.  
+It may contain non-working code. Before using it, run tests to ensure the code is working.
 
 ## Usage
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=dj{18,19,110}-py{27,35}-me{09,010}
+envlist=dj{18,19,110}-py{27,35}-me{09,010,011}
 
 [testenv]
 commands = ./runtests.py --nolint {posargs} --coverage
@@ -14,6 +14,8 @@ deps =
     me09: pymongo==2.*
     me010: mongoengine==0.10.*
     me010: pymongo==3.*
+    me011: mongoengine==0.11.*
+    me011: pymongo==3.*
 
 [testenv:py27-lint]
 commands = ./runtests.py --lintonly


### PR DESCRIPTION
Extended test specifications to include tests with Mongoengine 0.11.*.
Also extended README file accordingly.