### PR TITLE
Fix Attribute error with Reference Field

### DIFF
--- a/rest_framework_mongoengine/utils.py
+++ b/rest_framework_mongoengine/utils.py
@@ -210,7 +210,7 @@ def get_relation_kwargs(field_name, relation_info):
         if model_field.null:
             kwargs['allow_null'] = True
         if getattr(model_field, 'unique', False):
-            validator = UniqueValidator(queryset=model_field.model.objects)
+            validator = UniqueValidator(queryset=related_model.objects)
             kwargs['validators'] = [validator]
 
     return kwargs


### PR DESCRIPTION
This PR fixes the following bug: Cant find model attribute on Reference field 

i was doing 
```serializer = MySerializer(my_queryset, many=True)```

And not defining reference field explicitly in MySerializers.

So i am using related model instead(in the code)..which is the same

## Error screenshot
![pr1](https://cloud.githubusercontent.com/assets/5339740/25573827/6b2662de-2e66-11e7-8505-91ac76b45252.png)


