### PR TITLE
support mongoengine search

### DIFF
--- a/rest_framework_mongoengine/filters.py
+++ b/rest_framework_mongoengine/filters.py
@@ -1,0 +1,31 @@
+import operator
+from functools import reduce
+
+from django.utils import six
+from rest_framework.filters import SearchFilter
+from mongoengine.queryset.visitor import Q
+
+
+class MongoEngineSearchFilter(SearchFilter):
+
+    def filter_queryset(self, request, queryset, view):
+        search_fields = getattr(view, 'search_fields', None)
+        search_terms = self.get_search_terms(request)
+        if not search_fields or not search_terms:
+            return queryset
+
+        orm_lookups = [
+            self.construct_search(six.text_type(search_field))
+            for search_field in search_fields
+        ]
+
+        # base = queryset
+        conditions = []
+        for search_term in search_terms:
+            queries = [
+                Q(**{orm_lookup: search_term})
+                for orm_lookup in orm_lookups
+            ]
+            conditions.append(reduce(operator.or_, queries))
+        queryset = queryset.filter(reduce(operator.and_, conditions))
+        return queryset


### PR DESCRIPTION
support mongoengine search

in django settings.py
```.python
REST_FRAMEWORK = {
    'DEFAULT_FILTER_BACKENDS': [
        'django_rest_framework_mongoengine.filters.MongoEngineSearchFilter',
    ],
}
```