### PR TITLE
Add support for last version of DRF and Django 2 + add DateField

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 .env/
+venv/
 bin/
 build/
 develop-eggs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
     - "3.6"
-    - "3.8"
 
 services: mongodb
 
@@ -11,12 +10,8 @@ sudo: false
 env:
     - TOX_ENV=dj111-py36-me016
     - TOX_ENV=dj111-py36-me018
-    - TOX_ENV=dj111-py38-me016
-    - TOX_ENV=dj111-py38-me018
     - TOX_ENV=dj22-py36-me016
     - TOX_ENV=dj22-py36-me018
-    - TOX_ENV=dj22-py38-me016
-    - TOX_ENV=dj22-py38-me018
 
 matrix:
     fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 language: python
 
 python:
-    - "3.5"
+    - "3.6"
+    - "3.8"
 
 services: mongodb
 
 sudo: false
 
 env:
-    - TOX_ENV=py27-lint
-# We don't have documentation source in the repo, so no py27-docs yet:
-#    - TOX_ENV=py27-docs
     - TOX_ENV=dj111-py36-me016
     - TOX_ENV=dj111-py36-me018
     - TOX_ENV=dj111-py38-me016

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,24 +11,14 @@ env:
     - TOX_ENV=py27-lint
 # We don't have documentation source in the repo, so no py27-docs yet:
 #    - TOX_ENV=py27-docs
-    - TOX_ENV=dj18-py27-me09
-    - TOX_ENV=dj18-py35-me09
-    - TOX_ENV=dj18-py27-me010
-    - TOX_ENV=dj18-py35-me010
-    - TOX_ENV=dj18-py27-me011
-    - TOX_ENV=dj18-py35-me011
-    - TOX_ENV=dj19-py27-me09
-    - TOX_ENV=dj19-py35-me09
-    - TOX_ENV=dj19-py27-me010
-    - TOX_ENV=dj19-py35-me010
-    - TOX_ENV=dj19-py27-me011
-    - TOX_ENV=dj19-py35-me011
-    - TOX_ENV=dj110-py27-me09
-    - TOX_ENV=dj110-py35-me09
-    - TOX_ENV=dj110-py27-me010
-    - TOX_ENV=dj110-py35-me010
-    - TOX_ENV=dj110-py27-me011
-    - TOX_ENV=dj110-py35-me011
+    - TOX_ENV=dj111-py36-me016
+    - TOX_ENV=dj111-py36-me018
+    - TOX_ENV=dj111-py38-me016
+    - TOX_ENV=dj111-py38-me018
+    - TOX_ENV=dj22-py36-me016
+    - TOX_ENV=dj22-py36-me018
+    - TOX_ENV=dj22-py38-me016
+    - TOX_ENV=dj22-py38-me018
 
 matrix:
     fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     fast_finish: true
 
 install:
-    - pip install tox "virtualenv<14" djangorestframework codecov
+    - pip install tox virtualenv djangorestframework codecov
 
 script:
     - tox -e $TOX_ENV

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -3,4 +3,4 @@ pytest-cov
 pytest-django
 mock
 six
-
+pytz

--- a/rest_framework_mongoengine/repr.py
+++ b/rest_framework_mongoengine/repr.py
@@ -11,7 +11,6 @@ from django.utils.encoding import force_str
 from mongoengine.base import BaseDocument
 from mongoengine.fields import BaseField
 from mongoengine.queryset import QuerySet
-from rest_framework.compat import unicode_repr
 from rest_framework.fields import Field
 
 from rest_framework_mongoengine.fields import DictField
@@ -55,7 +54,7 @@ def smart_repr(value):
     if isinstance(value, Field):
         return field_repr(value)
 
-    value = unicode_repr(value)
+    value = repr(value)
 
     # Representations like u'help text'
     # should simply be presented as 'help text'

--- a/rest_framework_mongoengine/repr.py
+++ b/rest_framework_mongoengine/repr.py
@@ -38,6 +38,7 @@ def mongo_doc_repr(value):
         u = '[Bad Unicode data]'
     return force_str('<%s: %s>' % (value.__class__.__name__, u))
 
+
 uni_lit_re = re.compile("u'(.*?)'")
 
 

--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -7,7 +7,6 @@ from mongoengine import fields as me_fields
 from mongoengine.errors import ValidationError as me_ValidationError
 from rest_framework import fields as drf_fields
 from rest_framework import serializers
-from rest_framework.compat import unicode_to_repr
 from rest_framework.serializers import ALL_FIELDS
 from rest_framework.utils.field_mapping import ClassLookupDict
 
@@ -798,7 +797,7 @@ class DocumentSerializer(serializers.ModelSerializer):
         return []
 
     def __repr__(self):
-        return unicode_to_repr(serializer_repr(self, indent=1))
+        return repr(serializer_repr(self, indent=1))
 
 
 class EmbeddedDocumentSerializer(DocumentSerializer):

--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -87,6 +87,7 @@ class DocumentSerializer(serializers.ModelSerializer):
         * ``UUIDField``
         * ``GeoPointField``
         * ``GeoJsonBaseField`` (all those fields)
+        * ``DateField``
 
     Compound fields: ``ListField`` and ``DictField`` are mapped to corresponding DRF fields, with respect to nested field specification.
 
@@ -115,6 +116,7 @@ class DocumentSerializer(serializers.ModelSerializer):
         me_fields.DecimalField: drf_fields.DecimalField,
         me_fields.BooleanField: drf_fields.BooleanField,
         me_fields.DateTimeField: drf_fields.DateTimeField,
+        me_fields.DateField: drf_fields.DateField,
         me_fields.ComplexDateTimeField: drf_fields.DateTimeField,
         me_fields.ObjectIdField: drfm_fields.ObjectIdField,
         me_fields.FileField: drfm_fields.FileField,

--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -797,7 +797,7 @@ class DocumentSerializer(serializers.ModelSerializer):
         return []
 
     def __repr__(self):
-        return repr(serializer_repr(self, indent=1))
+        return serializer_repr(self, indent=1)
 
 
 class EmbeddedDocumentSerializer(DocumentSerializer):

--- a/rest_framework_mongoengine/validators.py
+++ b/rest_framework_mongoengine/validators.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from rest_framework import validators
-from rest_framework.compat import unicode_to_repr
 from rest_framework.exceptions import ValidationError
 from rest_framework.fields import SkipField
 
@@ -28,7 +27,7 @@ class UniqueValidator(MongoValidatorMixin, validators.UniqueValidator):
             raise ValidationError(self.message.format())
 
     def __repr__(self):
-        return unicode_to_repr('<%s(queryset=%s)>' % (
+        return repr('<%s(queryset=%s)>' % (
             self.__class__.__name__,
             smart_repr(self.queryset)
         ))
@@ -56,7 +55,7 @@ class UniqueTogetherValidator(MongoValidatorMixin, validators.UniqueTogetherVali
             raise ValidationError(self.message.format(field_names=field_names))
 
     def __repr__(self):
-        return unicode_to_repr('<%s(queryset=%s, fields=%s)>' % (
+        return repr('<%s(queryset=%s, fields=%s)>' % (
             self.__class__.__name__,
             smart_repr(self.queryset),
             smart_repr(self.fields)

--- a/rest_framework_mongoengine/validators.py
+++ b/rest_framework_mongoengine/validators.py
@@ -27,10 +27,10 @@ class UniqueValidator(MongoValidatorMixin, validators.UniqueValidator):
             raise ValidationError(self.message.format())
 
     def __repr__(self):
-        return repr('<%s(queryset=%s)>' % (
+        return '<%s(queryset=%s)>' % (
             self.__class__.__name__,
             smart_repr(self.queryset)
-        ))
+        )
 
 
 class UniqueTogetherValidator(MongoValidatorMixin, validators.UniqueTogetherValidator):
@@ -55,11 +55,11 @@ class UniqueTogetherValidator(MongoValidatorMixin, validators.UniqueTogetherVali
             raise ValidationError(self.message.format(field_names=field_names))
 
     def __repr__(self):
-        return repr('<%s(queryset=%s, fields=%s)>' % (
+        return '<%s(queryset=%s, fields=%s)>' % (
             self.__class__.__name__,
             smart_repr(self.queryset),
             smart_repr(self.fields)
-        ))
+        )
 
 
 class OptionalUniqueTogetherValidator(UniqueTogetherValidator):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def get_package_data(package):
 
 setup(
     name='django-rest-framework-mongoengine',
-    version='3.3.1',
+    version='3.4.0',
     description='MongoEngine support for Django Rest Framework.',
     packages=get_packages('rest_framework_mongoengine'),
     package_data=get_package_data('rest_framework_mongoengine'),

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def get_package_data(package):
 
 setup(
     name='django-rest-framework-mongoengine',
-    version='3.3.2',
+    version='3.3.1',
     description='MongoEngine support for Django Rest Framework.',
     packages=get_packages('rest_framework_mongoengine'),
     package_data=get_package_data('rest_framework_mongoengine'),

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def get_package_data(package):
 
 setup(
     name='django-rest-framework-mongoengine',
-    version='3.3.1',
+    version='3.3.2',
     description='MongoEngine support for Django Rest Framework.',
     packages=get_packages('rest_framework_mongoengine'),
     package_data=get_package_data('rest_framework_mongoengine'),

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -18,7 +18,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from mongoengine import Document, fields
 from rest_framework import serializers
-from rest_framework.compat import unicode_repr
 
 from rest_framework_mongoengine.serializers import DocumentSerializer
 
@@ -128,7 +127,7 @@ class TestRegularFieldMappings(TestCase):
                 custom_field = DocumentField(model_field=<tests.test_basic.CustomField: custom_field>, required=False)
         """ % regex_repr)
 
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_meta_fields(self):
         """
@@ -145,7 +144,7 @@ class TestRegularFieldMappings(TestCase):
                 str_field = CharField(required=False)
         """)
 
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_meta_exclude(self):
         """
@@ -180,7 +179,7 @@ class TestRegularFieldMappings(TestCase):
                 id_field = ObjectIdField(required=False)
         """ % regex_repr)
 
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_field_options(self):
         class TestSerializer(DocumentSerializer):
@@ -209,7 +208,7 @@ class TestRegularFieldMappings(TestCase):
         #         "('red', 'Red'), ('blue', 'Blue'), ('green', 'Green')",
         #         "(u'red', u'Red'), (u'blue', u'Blue'), (u'green', u'Green')"
         #     )
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_method_field(self):
         """
@@ -226,7 +225,7 @@ class TestRegularFieldMappings(TestCase):
                 id = ObjectIdField(read_only=True)
                 method = ReadOnlyField()
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_pk_fields(self):
         """
@@ -242,7 +241,7 @@ class TestRegularFieldMappings(TestCase):
                 pk = IntegerField(read_only=True)
                 auto_field = IntegerField(read_only=True)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_id_field(self):
         """
@@ -257,7 +256,7 @@ class TestRegularFieldMappings(TestCase):
             TestSerializer():
                 id = ObjectIdField(read_only=True)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_extra_field_kwargs(self):
         """
@@ -274,7 +273,7 @@ class TestRegularFieldMappings(TestCase):
                 id = ObjectIdField(read_only=True)
                 str_field = CharField(default='extra')
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_invalid_field(self):
         """

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 from mongoengine import Document, fields
-from rest_framework.compat import unicode_repr
 
 from rest_framework_mongoengine.serializers import DocumentSerializer
 
@@ -47,7 +46,7 @@ class TestCompundFieldMappings(TestCase):
                 int_dict_field = DictField(child=IntegerField(required=False), required=False)
                 int_map_field = DictField(child=IntegerField(required=False), required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_suboptions(self):
         class TestSerializer(DocumentSerializer):
@@ -60,7 +59,7 @@ class TestCompundFieldMappings(TestCase):
                 id = ObjectIdField(read_only=True)
                 int_list_field = ListField(child=IntegerField(max_value=7, min_value=3, required=False), required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_nested(self):
         class TestSerializer(DocumentSerializer):
@@ -75,7 +74,7 @@ class TestCompundFieldMappings(TestCase):
                 list_dict_field = DictField(child=ListField(required=False), required=False)
                 list_dict_list_field = ListField(child=DictField(child=ListField(required=False), required=False), required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
 
 class TestSerializer(DocumentSerializer):

--- a/tests/test_dumb.py
+++ b/tests/test_dumb.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 from rest_framework import fields
-from rest_framework.compat import unicode_repr
 
 from rest_framework_mongoengine.serializers import DocumentSerializer
 
@@ -49,7 +48,7 @@ class TestMapping(TestCase):
         """)
 
         # better output then self.assertEqual()
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
 
 class TestSerializer(DocumentSerializer):

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -4,7 +4,6 @@ import json
 
 from django.test import TestCase
 from rest_framework import fields as drf_fields
-from rest_framework.compat import unicode_repr
 
 from rest_framework_mongoengine.serializers import (
     DocumentSerializer, DynamicDocumentSerializer, EmbeddedDocumentSerializer
@@ -83,7 +82,7 @@ class TestDynamicMapping(TestCase):
                 name = CharField(required=False)
                 foo = IntegerField(required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_extended(self):
         class TestSerializer(DynamicDocumentSerializer):
@@ -100,7 +99,7 @@ class TestDynamicMapping(TestCase):
                 name = CharField(required=False)
                 foo = IntegerField(required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
 
 class TestSerializer(DynamicDocumentSerializer):
@@ -216,7 +215,7 @@ class TestEmbeddingDynamicMapping(TestCase):
                     name = CharField(required=False)
                     foo = IntegerField(required=False)
         """)
-        assert unicode_repr(EmbeddingDynamicSerializer()) == expected
+        assert repr(EmbeddingDynamicSerializer()) == expected
 
 
 class TestEmbeddingDynamicIntegration(TestCase):
@@ -326,7 +325,7 @@ class TestDocumentEmbeddingDynamicMapping(TestCase):
                     name = CharField(required=False)
                     foo = IntegerField(required=False)
         """)
-        assert unicode_repr(DocumentEmbeddingDynamicSerializer()) == expected
+        assert repr(DocumentEmbeddingDynamicSerializer()) == expected
 
 
 class TestDocumentEmbeddingDynamicIntegration(TestCase):

--- a/tests/test_embedded.py
+++ b/tests/test_embedded.py
@@ -613,7 +613,7 @@ class TestEmbeddedValidation(TestCase):
         serializer = ValidatingListSerializer(data={'embedded_list': [{'text': 'Fo'}]})
         assert not serializer.is_valid()
         assert 'embedded_list' in serializer.errors
-        assert 'text' in serializer.errors['embedded_list']
+        assert 'text' in serializer.errors['embedded_list'][0]
 
     def test_nested_validation_passing(self):
         serializer = ValidatingListSerializer(data={'embedded_list': [{'text': 'Text'}]})

--- a/tests/test_embedded.py
+++ b/tests/test_embedded.py
@@ -10,7 +10,6 @@ from rest_framework_mongoengine.fields import DocumentField
 from rest_framework_mongoengine.serializers import (
     DocumentSerializer, EmbeddedDocumentSerializer
 )
-
 from .models import DumbEmbedded, OtherEmbedded
 from .utils import dedent
 
@@ -55,6 +54,7 @@ class TestEmbeddingMapping(TestCase):
             class Meta:
                 model = DumbEmbedded
                 fields = '__all__'
+
         expected = dedent("""
             TestSerializer():
                 name = CharField(required=False)
@@ -68,6 +68,7 @@ class TestEmbeddingMapping(TestCase):
                 model = NestedEmbeddingDoc
                 fields = '__all__'
                 depth = 1
+
         expected = dedent("""
             TestSerializer():
                 id = ObjectIdField(read_only=True)
@@ -85,6 +86,7 @@ class TestEmbeddingMapping(TestCase):
                 model = NestedEmbeddingDoc
                 fields = '__all__'
                 depth = 0
+
         expected = dedent("""
             TestSerializer():
                 id = ObjectIdField(read_only=True)
@@ -102,6 +104,7 @@ class TestEmbeddingMapping(TestCase):
                 model = NestedEmbeddingDoc
                 fields = '__all__'
                 depth_embedding = 1
+
         expected = dedent("""
             TestSerializer():
                 id = ObjectIdField(read_only=True)
@@ -142,6 +145,7 @@ class TestEmbeddingMapping(TestCase):
                 model = RecursiveEmbeddingDoc
                 fields = '__all__'
                 depth_embedding = 2
+
         expected = dedent("""
             TestSerializer():
                 id = ObjectIdField(read_only=True)
@@ -160,6 +164,7 @@ class TestEmbeddingMapping(TestCase):
             class Meta:
                 model = NestedEmbeddingDoc
                 fields = '__all__'
+
         expected = dedent("""
             TestSerializer():
                 id = ObjectIdField(read_only=True)
@@ -176,6 +181,7 @@ class TestEmbeddingMapping(TestCase):
             class Meta:
                 model = ListEmbeddingDoc
                 fields = '__all__'
+
         expected = dedent("""
             TestSerializer():
                 id = ObjectIdField(read_only=True)
@@ -190,6 +196,7 @@ class TestEmbeddingMapping(TestCase):
             class Meta:
                 model = RequiredEmbeddingDoc
                 fields = '__all__'
+
         expected = dedent("""
             TestSerializer():
                 id = ObjectIdField(read_only=True)
@@ -213,7 +220,6 @@ class TestEmbeddingMapping(TestCase):
         assert repr(TestSerializer()) == expected
 
     def test_embedding_custom_generic(self):
-
         class CustomEmbedding(DocumentField):
             pass
 
@@ -284,8 +290,10 @@ class NestedEmbeddingSerializer(DocumentSerializer):
 
 class TestEmbeddedIntegration(TestCase):
     """ should work on isolated embedded docs """
+
     def test_retrieve(self):
         """ serializing standalone doc """
+
         class TestSerializer(EmbeddedDocumentSerializer):
             class Meta:
                 model = OtherEmbedded
@@ -298,6 +306,7 @@ class TestEmbeddedIntegration(TestCase):
 
     def test_create(self):
         """ creating standalone instance """
+
         class TestSerializer(EmbeddedDocumentSerializer):
             class Meta:
                 model = OtherEmbedded
@@ -315,10 +324,12 @@ class TestEmbeddedIntegration(TestCase):
 
     def test_update(self):
         """ updating standalone instance with partial data """
+
         class TestSerializer(EmbeddedDocumentSerializer):
             class Meta:
                 model = OtherEmbedded
                 fields = '__all__'
+
         instance = OtherEmbedded(name="qwe", bar=123)
         data = {'bar': 234}
 

--- a/tests/test_embedded.py
+++ b/tests/test_embedded.py
@@ -4,7 +4,6 @@ import pytest
 from django.test import TestCase
 from mongoengine import Document, EmbeddedDocument, fields
 from rest_framework import fields as drf_fields
-from rest_framework.compat import unicode_repr
 from rest_framework.serializers import Field, Serializer
 
 from rest_framework_mongoengine.fields import DocumentField
@@ -61,7 +60,7 @@ class TestEmbeddingMapping(TestCase):
                 name = CharField(required=False)
                 foo = IntegerField(required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_embedding(self):
         class TestSerializer(DocumentSerializer):
@@ -78,7 +77,7 @@ class TestEmbeddingMapping(TestCase):
                         name = CharField(required=False)
                         foo = IntegerField(required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_embedding_nodepth(self):
         class TestSerializer(DocumentSerializer):
@@ -95,7 +94,7 @@ class TestEmbeddingMapping(TestCase):
                         name = CharField(required=False)
                         foo = IntegerField(required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_embedding_restricted(self):
         class TestSerializer(DocumentSerializer):
@@ -110,7 +109,7 @@ class TestEmbeddingMapping(TestCase):
                     name = CharField(required=False)
                     embedded = HiddenField(default=None, required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_embedding_recursive(self):
         class TestSerializer(DocumentSerializer):
@@ -135,7 +134,7 @@ class TestEmbeddingMapping(TestCase):
         """)
 
         serializer = TestSerializer()
-        assert unicode_repr(serializer) == expected
+        assert repr(serializer) == expected
 
     def test_embedding_recursive_restricted(self):
         class TestSerializer(DocumentSerializer):
@@ -154,7 +153,7 @@ class TestEmbeddingMapping(TestCase):
         """)
 
         serializer = TestSerializer()
-        assert unicode_repr(serializer) == expected
+        assert repr(serializer) == expected
 
     def test_embedding_nested(self):
         class TestSerializer(DocumentSerializer):
@@ -170,7 +169,7 @@ class TestEmbeddingMapping(TestCase):
                         name = CharField(required=False)
                         foo = IntegerField(required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_embedding_list(self):
         class TestSerializer(DocumentSerializer):
@@ -184,7 +183,7 @@ class TestEmbeddingMapping(TestCase):
                     name = CharField(required=False)
                     foo = IntegerField(required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_embedding_required(self):
         class TestSerializer(DocumentSerializer):
@@ -198,7 +197,7 @@ class TestEmbeddingMapping(TestCase):
                     name = CharField(required=False)
                     foo = IntegerField(required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_embedding_generic(self):
         class TestSerializer(DocumentSerializer):
@@ -211,7 +210,7 @@ class TestEmbeddingMapping(TestCase):
                 id = ObjectIdField(read_only=True)
                 embedded = GenericEmbeddedDocumentField(model_field=<mongoengine.fields.GenericEmbeddedDocumentField: embedded>, required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_embedding_custom_generic(self):
 
@@ -230,7 +229,7 @@ class TestEmbeddingMapping(TestCase):
                 id = ObjectIdField(read_only=True)
                 embedded = CustomEmbedding(model_field=<mongoengine.fields.GenericEmbeddedDocumentField: embedded>, required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_embedding_custom_nested(self):
         class CustomTestSerializer(Serializer):
@@ -249,7 +248,7 @@ class TestEmbeddingMapping(TestCase):
                 embedded = EmbeddedSerializer(required=False):
                     bla = CharField()
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_embedding_custom_bottom(self):
         class CustomEmbedding(Field):
@@ -268,7 +267,7 @@ class TestEmbeddingMapping(TestCase):
                 id = ObjectIdField(read_only=True)
                 embedded = CustomEmbedding(default=None, required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
 
 class EmbeddingSerializer(DocumentSerializer):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -6,7 +6,6 @@ import sys
 from django.core.files.uploadedfile import UploadedFile
 from django.test import TestCase
 from mongoengine import Document, fields
-from rest_framework.compat import unicode_repr
 
 from rest_framework_mongoengine.serializers import DocumentSerializer
 
@@ -54,7 +53,7 @@ class TestFilesMapping(TestCase):
                 i = ImageField(required=False)
         """)
 
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
 
 class TestFilesIntegration(TestCase):

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 from mongoengine import Document, fields
-from rest_framework.compat import unicode_repr
 
 from rest_framework_mongoengine.fields import GeoJSONField, GeoPointField
 from rest_framework_mongoengine.serializers import DocumentSerializer
@@ -168,4 +167,4 @@ class TestGeoMapping(TestCase):
                 multi_line_field = GeoJSONField(geo_type='MultiLineString', required=False)
                 multi_poly_field = GeoJSONField(geo_type='MultiPolygon', required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected

--- a/tests/test_nested_customization.py
+++ b/tests/test_nested_customization.py
@@ -12,7 +12,6 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 from mongoengine import Document, EmbeddedDocument, fields
-from rest_framework.compat import unicode_repr
 from rest_framework.serializers import ValidationError
 
 from rest_framework_mongoengine.serializers import DocumentSerializer
@@ -62,7 +61,7 @@ class TestNestedCustomizationMapping(TestCase):
                 nested_reference = NestedSerializer(read_only=True):
                     foo = CharField(required=False)
         """)
-        assert unicode_repr(ParentSerializer()) == expected
+        assert repr(ParentSerializer()) == expected
 
     def test_exclude(self):
         """Ensure `exclude` is passed to embedded documents."""
@@ -83,7 +82,7 @@ class TestNestedCustomizationMapping(TestCase):
                     name = CharField(required=False)
         """)
 
-        assert unicode_repr(ParentSerializer()) == expected
+        assert repr(ParentSerializer()) == expected
 
     def test_read_only(self):
         """Ensure `read_only` are passed to embedded documents."""
@@ -107,7 +106,7 @@ class TestNestedCustomizationMapping(TestCase):
                     age = IntegerField(required=False)
         """)
 
-        assert unicode_repr(ParentSerializer()) == expected
+        assert repr(ParentSerializer()) == expected
 
     def test_extra_field_kwargs(self):
         """Ensure `extra_kwargs` are passed to embedded documents."""
@@ -134,7 +133,7 @@ class TestNestedCustomizationMapping(TestCase):
                     age = IntegerField(required=False)
         """)
 
-        assert unicode_repr(ParentSerializer()) == expected
+        assert repr(ParentSerializer()) == expected
 
 
 class TestCompoundCustomizationMapping(TestCase):
@@ -163,9 +162,9 @@ class TestCompoundCustomizationMapping(TestCase):
         """)
 
         serializer = CompoundParentSerializer()
-        unicode_repr(serializer)
+        repr(serializer)
 
-        assert unicode_repr(CompoundParentSerializer()) == expected
+        assert repr(CompoundParentSerializer()) == expected
 
     def test_exclude(self):
         """Ensure `exclude` is passed to embedded documents."""
@@ -190,7 +189,7 @@ class TestCompoundCustomizationMapping(TestCase):
                     age = IntegerField(required=False)
         """)
 
-        assert unicode_repr(CompoundParentSerializer()) == expected
+        assert repr(CompoundParentSerializer()) == expected
 
     def test_read_only(self):
         """Ensure `read_only` are passed to embedded documents."""
@@ -220,7 +219,7 @@ class TestCompoundCustomizationMapping(TestCase):
                     age = IntegerField(required=False)
         """)
 
-        assert unicode_repr(CompoundParentSerializer()) == expected
+        assert repr(CompoundParentSerializer()) == expected
 
     def test_extra_field_kwargs(self):
         class CompoundParentSerializer(DocumentSerializer):
@@ -250,7 +249,7 @@ class TestCompoundCustomizationMapping(TestCase):
                     age = IntegerField(required=False)
         """)
 
-        assert unicode_repr(CompoundParentSerializer()) == expected
+        assert repr(CompoundParentSerializer()) == expected
 
 
 class TestNestedCustomizationFieldsIntegration(TestCase):

--- a/tests/test_nested_customization.py
+++ b/tests/test_nested_customization.py
@@ -751,7 +751,7 @@ class TestNestedCustomizationValidateMethodIntegration(TestCase):
 
         serializer = self.ParentSerializer(instance, data=data)
         assert not serializer.is_valid()
-        assert serializer.errors == {'embedded': {'name': [u'Minimum 4 characters.']}}
+        assert dict(serializer.errors) == {'embedded': {'name': [u'Minimum 4 characters.']}}
 
 
 class TestNestedCompoundCustomizationFieldsIntegration(TestCase):
@@ -1331,7 +1331,7 @@ class TestNestedCompoundCustomizationValidateMethodIntegration(TestCase):
 
         serializer = self.CompoundParentSerializer(data=data)
         assert not serializer.is_valid()
-        assert serializer.errors == {'embedded_list': {'name': [u'Minimum 4 characters.']}}
+        assert dict(serializer.errors) == {'embedded_list': {0: {'name': [u'Minimum 4 characters.']}}}
 
     def test_update_success(self):
         instance = CompoundParentDocument.objects.create(
@@ -1378,4 +1378,4 @@ class TestNestedCompoundCustomizationValidateMethodIntegration(TestCase):
 
         serializer = self.CompoundParentSerializer(instance, data=data)
         assert not serializer.is_valid()
-        assert serializer.errors == {'embedded_list': {'name': [u'Minimum 4 characters.']}}
+        assert dict(serializer.errors) == {'embedded_list': {0: {'name': [u'Minimum 4 characters.']}}}

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 from bson import DBRef
 from django.test import TestCase
 from mongoengine import Document, fields
-from rest_framework.compat import unicode_repr
 from rest_framework.fields import IntegerField
 from rest_framework.serializers import Serializer
 
@@ -257,7 +256,8 @@ class TestReferenceMapping(TestCase):
                 cached = ReferenceField(queryset=ReferencedDoc.objects, required=False)
                 generic = GenericReferenceField(required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
+
 
     def test_shallow(self):
         class TestSerializer(DocumentSerializer):
@@ -271,7 +271,7 @@ class TestReferenceMapping(TestCase):
                 id = ObjectIdField(read_only=True)
                 ref = ReferenceField(queryset=ReferencedDoc.objects, required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_deep(self):
         class TestSerializer(DocumentSerializer):
@@ -287,7 +287,7 @@ class TestReferenceMapping(TestCase):
                     id = ObjectIdField(read_only=True)
                     name = CharField(required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_recursive(self):
         class TestSerializer(DocumentSerializer):
@@ -307,7 +307,7 @@ class TestReferenceMapping(TestCase):
                             id = ObjectIdField(read_only=True)
                             ref = ReferenceField(queryset=RecursiveReferencingDoc.objects, required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_custom_field(self):
 
@@ -327,7 +327,7 @@ class TestReferenceMapping(TestCase):
                 id = ObjectIdField(read_only=True)
                 ref = ReferenceField(queryset=ReferencedDoc.objects, required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_custom_generic(self):
         class CustomReferencing(GenericReferenceField):
@@ -346,7 +346,7 @@ class TestReferenceMapping(TestCase):
                 id = ObjectIdField(read_only=True)
                 ref = CustomReferencing(required=False)
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
     def test_custom_nested(self):
         class CustomReferencing(Serializer):
@@ -366,7 +366,7 @@ class TestReferenceMapping(TestCase):
                 ref = NestedSerializer(read_only=True):
                     foo = IntegerField()
         """)
-        assert unicode_repr(TestSerializer()) == expected
+        assert repr(TestSerializer()) == expected
 
 
 class DisplayableReferencedModel(Document):

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -258,7 +258,6 @@ class TestReferenceMapping(TestCase):
         """)
         assert repr(TestSerializer()) == expected
 
-
     def test_shallow(self):
         class TestSerializer(DocumentSerializer):
             class Meta:
@@ -310,7 +309,6 @@ class TestReferenceMapping(TestCase):
         assert repr(TestSerializer()) == expected
 
     def test_custom_field(self):
-
         class CustomReferencing(ReferenceField):
             pass
 
@@ -709,6 +707,7 @@ class ComboReferencingSerializer(DocumentSerializer):
     class Meta:
         model = ReferencingDoc
         fields = '__all__'
+
     ref = ComboReferenceField(serializer=ReferencedSerializer)
 
     def save_subdocs(self, validated_data):
@@ -750,6 +749,7 @@ class TestComboReferenceIntegration(TestCase):
                 model = ReferencingDoc
                 fields = '__all__'
                 depth = 1
+
             ref = ComboReferenceField(serializer=ReferencedSerializer)
 
         serializer = TestSerializer(instance)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -8,7 +8,6 @@ from rest_framework_mongoengine.serializers import DocumentSerializer
 from rest_framework_mongoengine.validators import (
     UniqueTogetherValidator, UniqueValidator
 )
-
 from .utils import dedent
 
 
@@ -220,6 +219,7 @@ class TestUniqueTogetherValidation(TestCase):
             class Meta:
                 model = NullValidatingModel
                 fields = '__all__'
+
         data = {'name': 'existing', 'code': None, 'other': "xxx"}
         serializer = NullUniqueTogetherValidatorSerializer(data=data)
         assert serializer.is_valid(), serializer.errors
@@ -277,6 +277,7 @@ class TestUniqueTogetherSerializer(TestCase):
         When model fields are not included in a serializer and have no defaults,
         then uniqueness validators should not be added for that field.
         """
+
         class UniqueTogetherSerializer(DocumentSerializer):
             class Meta:
                 model = UniqueTogetherModel

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=dj{111,22}-py{36,38}-me{016,018}
+envlist=dj{111,22}-py{36}-me{016,018}
 
 [testenv]
 commands = ./runtests.py --nolint {posargs} --coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,21 @@
 [tox]
-envlist=dj{18,19,110}-py{27,35}-me{09,010,011}
+envlist=dj{110,21,22}-py{35,36,38}-me{016,017,018}
 
 [testenv]
 commands = ./runtests.py --nolint {posargs} --coverage
 deps =
     -rrequirements/requirements-testing.txt
-    dj18: Django==1.8.*
-    dj19: Django==1.9.*
     dj110: Django==1.10.*
+    dj21: Django==2.1.*
+    dj22: Django==2.2.*
     djangorestframework==3.*
     blinker==1.*
-    me09: mongoengine==0.9.*
-    me09: pymongo==2.*
-    me010: mongoengine==0.10.*
-    me010: pymongo==3.*
-    me011: mongoengine==0.11.*
-    me011: pymongo==3.*
+    me016: mongoengine==0.16.*
+    me016: pymongo==3.*
+    me017: mongoengine==0.17.*
+    me017: pymongo==3.*
+    me018: mongoengine==0.18.*
+    me018: pymongo==3.*
 
 [testenv:py27-lint]
 commands = ./runtests.py --lintonly

--- a/tox.ini
+++ b/tox.ini
@@ -14,12 +14,6 @@ deps =
     me018: mongoengine==0.18.*
     me018: pymongo==3.*
 
-[testenv:py27-lint]
-commands = ./runtests.py --lintonly
-deps =
-        -rrequirements/requirements-codestyle.txt
-        -rrequirements/requirements-testing.txt
-
 # We don't have any documentation source in the repository yet, so
 # documentation generation is commented-out. Sphinx or Markdown?
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,16 @@
 [tox]
-envlist=dj{110,21,22}-py{35,36,38}-me{016,017,018}
+envlist=dj{111,22}-py{36,38}-me{016,018}
 
 [testenv]
 commands = ./runtests.py --nolint {posargs} --coverage
 deps =
     -rrequirements/requirements-testing.txt
-    dj110: Django==1.10.*
-    dj21: Django==2.1.*
+    dj111: Django==1.11.*
     dj22: Django==2.2.*
     djangorestframework==3.*
     blinker==1.*
     me016: mongoengine==0.16.*
     me016: pymongo==3.*
-    me017: mongoengine==0.17.*
-    me017: pymongo==3.*
     me018: mongoengine==0.18.*
     me018: pymongo==3.*
 


### PR DESCRIPTION
Tested on:
Django==1.11.*
Django==2.2.*

djangorestframework==3.*

mongoengine==0.16.*
mongoengine==0.18.*