### PR TITLE
Allow nullable EmbeddedDocumentLists to be set to None

### DIFF
--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -222,9 +222,11 @@ class DocumentSerializer(serializers.ModelSerializer):
             try:
                 field = self.fields[key]
 
+                if value is None: # issue when the value is none
+                    me_data[key] = value
                 # for EmbeddedDocumentSerializers, call recursive_save
-                if isinstance(field, EmbeddedDocumentSerializer):
-                    me_data[key] = field.recursive_save(value) if value is not None else value # issue when the value is none 
+                elif isinstance(field, EmbeddedDocumentSerializer):
+                    me_data[key] = field.recursive_save(value)
 
                 # same for lists of EmbeddedDocumentSerializers i.e.
                 # ListField(EmbeddedDocumentField) or EmbeddedDocumentListField

--- a/tests/test_embedded.py
+++ b/tests/test_embedded.py
@@ -40,6 +40,10 @@ class ListEmbeddingDoc(Document):
     embedded_list = fields.EmbeddedDocumentListField(DumbEmbedded)
 
 
+class NullableListEmbeddingDoc(Document):
+    embedded_list = fields.EmbeddedDocumentListField(DumbEmbedded, null=True)
+
+
 class RecursiveEmbeddingDoc(Document):
     embedded = fields.EmbeddedDocumentField(SelfEmbeddingDoc)
 
@@ -279,6 +283,12 @@ class TestEmbeddingMapping(TestCase):
 class EmbeddingSerializer(DocumentSerializer):
     class Meta:
         model = EmbeddingDoc
+        fields = '__all__'
+
+
+class NullableListEmbeddingSerializer(DocumentSerializer):
+    class Meta:
+        model = NullableListEmbeddingDoc
         fields = '__all__'
 
 
@@ -581,6 +591,24 @@ class TestListEmbeddingIntegration(TestCase):
     @pytest.mark.skipif(True, reason="TODO")
     def test_update_partial(self):
         pass
+
+    def test_list_none(self):
+        data = {
+            'embedded_list': None,
+        }
+
+        serializer = NullableListEmbeddingSerializer(data=data)
+        assert serializer.is_valid(), serializer.errors
+
+        instance = serializer.save()
+        assert isinstance(instance, NullableListEmbeddingDoc)
+        assert instance.embedded_list is None
+
+        expected = {
+            'id': str(instance.id),
+            'embedded_list': None,
+        }
+        assert serializer.data == expected
 
 
 class ValidatingEmbeddedModel(EmbeddedDocument):


### PR DESCRIPTION
The case for a nullable EmbeddedDocumentField was handled in commit
d1543516e841, but the other two branches (EmbeddedDocumentList and
DictField) need this handling as well. Add a test for EmbeddedDocumentList
and fix in a generic way. This fixes issue #250.