### PR TITLE
Add `style` to field kwargs.

### DIFF
--- a/rest_framework_mongoengine/utils.py
+++ b/rest_framework_mongoengine/utils.py
@@ -21,7 +21,6 @@ RelationInfo = namedtuple('RelationInfo', [
     'related_model'
 ])
 
-
 NUMERIC_FIELD_TYPES = (
     me_fields.IntField,
     me_fields.LongField,
@@ -125,6 +124,9 @@ def get_field_kwargs(field_name, model_field):
     if hasattr(model_field, 'help_text'):
         kwargs['help_text'] = model_field.help_text
 
+    if hasattr(model_field, 'style'):
+        kwargs['style'] = model_field.style
+
     if isinstance(model_field, me_fields.DecimalField):
         precision = model_field.precision
         max_value = getattr(model_field, 'max_value', None)
@@ -204,6 +206,8 @@ def get_relation_kwargs(field_name, relation_info):
             kwargs['label'] = capfirst(model_field.verbose_name)
         if hasattr(model_field, 'help_text'):
             kwargs['help_text'] = model_field.help_text
+        if hasattr(model_field, 'style'):
+            kwargs['style'] = model_field.style
 
         kwargs['required'] = model_field.required
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -79,6 +79,7 @@ class FieldOptionsModel(Document):
     length_limit_field = fields.StringField(min_length=3, max_length=12)
     value_limit_field = fields.IntField(min_value=3, max_value=12)
     decimal_field = fields.DecimalField(precision=4, max_value=9999)
+    style_field = fields.StringField(style={'placeholder': 'Style placeholder', 'base_template': 'style.html'})
 
 
 DECIMAL_CHOICES = (('low', Decimal('0.1')), ('medium', Decimal('0.5')), ('high', Decimal('0.9')))
@@ -195,7 +196,8 @@ class TestRegularFieldMappings(TestCase):
                 length_limit_field = CharField(max_length=12, min_length=3, required=False)
                 value_limit_field = IntegerField(max_value=12, min_value=3, required=False)
                 decimal_field = DecimalField(decimal_places=4, max_digits=8, max_value=9999, required=False)
-        """)
+                style_field = CharField(required=False, style={'placeholder': 'Style placeholder', 'base_template': 'style.html'})
+                """)
 
         assert repr(TestSerializer()) == expected
 

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -19,7 +19,7 @@ class BasicCompoundDoc(Document):
 
 
 class OptionsCompoundDoc(Document):
-    int_list_field = fields.ListField(fields.IntField(min_value=3, max_value=7))
+    int_list_field = fields.ListField(fields.IntField(min_value=3, max_value=7, style={'color': 'red'}))
 
 
 class NestedCompoundDoc(Document):
@@ -57,7 +57,7 @@ class TestCompundFieldMappings(TestCase):
         expected = dedent("""
             TestSerializer():
                 id = ObjectIdField(read_only=True)
-                int_list_field = ListField(child=IntegerField(max_value=7, min_value=3, required=False), required=False)
+                int_list_field = ListField(child=IntegerField(max_value=7, min_value=3, required=False, style={'color': 'red'}), required=False)
         """)
         assert repr(TestSerializer()) == expected
 


### PR DESCRIPTION
This means that the DRF field gets built with the `style` kwarg set to what is defined in the mongoengine field.
Fixes #288 